### PR TITLE
simplify leaderboard/queue route

### DIFF
--- a/pages/api/leaderboard/queue.ts
+++ b/pages/api/leaderboard/queue.ts
@@ -1,29 +1,15 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import Instances from "../../../models/Instance";
 
-
-const buildQueue = async (customerId: string | string[] | undefined) => {
-  const instances = await Instances.find({ customerId: customerId, status: "queued" })
-  const noInstances: Boolean = instances.length === 0
-  if (noInstances) return { success: false, error: 'No instances for customerId!' }
-  const queue = instances.sort((b: any, c: any) => (b.queueTimestamp < c.queueTimestamp) ? 1 : -1).sort((b: any, c: any) => (b.runningTotal < c.runningTotal) ? 1 : -1)
-  return { success: true, queue: queue }
-}
-
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    if (req.method === 'POST') {
-      const { customerId } = req.body;
-      const post: any = await buildQueue(customerId);
-      if (!post.success) return res.status(400).json(post);
-      return res.status(200).json(post);
-    } else if (req.method === 'GET') {
-      const { customerId } = req.query;
-      const get: any = await buildQueue(customerId);
-      get.queue[0].status = "next"
-      if (!get.success) return res.status(400).json(get);
-      return res.status(200).json(get);
-    }
+    const { customerId, next } = req.query;
+    const instances = await Instances.find({ customerId: customerId, status: "queued" })
+    const noInstances: Boolean = instances.length === 0
+    if (noInstances) return res.status(400).json({ success: false, error: 'No instances for customerId!' })
+    const queue = instances.sort((b: any, c: any) => (b.queueTimestamp < c.queueTimestamp) ? 1 : -1).sort((b: any, c: any) => (b.runningTotal < c.runningTotal) ? 1 : -1)
+    if (next && next === 'true') queue[0].status = "next"
+    return res.status(200).json({ success: true, queue: queue });
   } catch (error) {
     return res.status(400).json({ success: false, error: error });
   }


### PR DESCRIPTION
- make the route GET only using query params
- example url `http://localhost:3000/api/leaderboard/queue?customerId=638bd6f5837e91948a592a8b&next=true`
- required: `customerId={customerId}` -- used to find the Instance queue corresponding to that customer / host
- optional: `next={true | false}` song -- used to tell the backend to set the first song in the queue as the "next" song